### PR TITLE
Add support for management policies

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -49,6 +49,8 @@ func main() {
 
 		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
+        enableManagementPolicies   = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("false").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
+
 	)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -85,17 +87,20 @@ func main() {
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add HSDP APIs to scheme")
+	
+	featureFlags := &feature.Flags{}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,
 			GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
 			PollInterval:            1 * time.Minute,
 			MaxConcurrentReconciles: 1,
+			Features:                featureFlags,
 		},
 		Provider: config.GetProvider(),
 		// use the following WorkspaceStoreOption to enable the shared gRPC mode
 		// terraform.WithProviderRunner(terraform.NewSharedProvider(log, os.Getenv("TERRAFORM_NATIVE_PROVIDER_PATH"), terraform.WithNativeProviderArgs("-debuggable")))
-		WorkspaceStore: terraform.NewWorkspaceStore(log),
+		WorkspaceStore: terraform.NewWorkspaceStore(log, terraform.WithFeatures(featureFlags)),
 		SetupFn:        clients.TerraformSetupBuilder(*terraformVersion, *providerSource, *providerVersion),
 	}
 
@@ -116,6 +121,11 @@ func main() {
 				},
 			},
 		})), "cannot create default store config")
+	}
+	
+	if *enableManagementPolicies {
+	    o.Features.Enable(features.EnableAlphaManagementPolicies)
+	    log.Info("Alpha feature enabled", "flag", features.EnableAlphaManagementPolicies)
 	}
 
 	kingpin.FatalIfError(controller.Setup(mgr, o), "Cannot setup HSDP controllers")

--- a/config/provider.go
+++ b/config/provider.go
@@ -32,6 +32,7 @@ func GetProvider() *ujconfig.Provider {
 		ujconfig.WithShortName("hsdp"),
 		ujconfig.WithRootGroup("hsdp.crossplane.io"),
 		ujconfig.WithIncludeList(ExternalNameConfigured()),
+		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithDefaultResourceOptions(
 			ExternalNameConfigurations(),
 		))

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -12,4 +12,9 @@ const (
 	// External Secret Stores. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
 	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
+	
+	// EnableAlphaManagementPolicies enables alpha support for
+    // Management Policies. See the below design for more details.
+    // https://github.com/crossplane/crossplane/pull/3531
+    EnableAlphaManagementPolicies feature.Flag = "EnableAlphaManagementPolicies"
 )


### PR DESCRIPTION
Add support for [management policies](https://docs.crossplane.io/v1.14/concepts/managed-resources/#managementpolicies) according to [upjet docs](https://github.com/crossplane/upjet/blob/main/docs/adding-support-for-management-policies.md)