### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request_target: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   # Common versions
   GO_VERSION: '1.24.3'


### PR DESCRIPTION
Potential fix for [https://github.com/philips-software/provider-hsdp/security/code-scanning/9](https://github.com/philips-software/provider-hsdp/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves reading repository contents, caching dependencies, and publishing test coverage, the permissions should be set to `contents: read` globally, with additional permissions (e.g., `pull-requests: write`) added only if necessary for specific jobs.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs for more granular control. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
