### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   # Common versions
   GO_VERSION: '1.21.6'


### PR DESCRIPTION
Potential fix for [https://github.com/philips-software/provider-hsdp/security/code-scanning/5](https://github.com/philips-software/provider-hsdp/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's tasks, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for publishing Docker images and artifacts.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. If specific jobs require different permissions, additional `permissions` blocks can be added within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
