### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -10,6 +10,9 @@ on:
         description: 'Tag message'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/philips-software/provider-hsdp/security/code-scanning/7](https://github.com/philips-software/provider-hsdp/security/code-scanning/7)

To fix the issue, add a `permissions` block to the workflow. Since the workflow involves creating tags, it requires `contents: write` permission. This permission should be explicitly defined at the workflow level or within the `create-tag` job. Adding the `permissions` block at the workflow level ensures that all jobs in the workflow inherit the same permissions unless overridden.

The fix involves:
1. Adding a `permissions` block at the root of the workflow file.
2. Setting `contents: write` to allow the workflow to create tags.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
